### PR TITLE
$_REQUEST keeps numerical indexes when merging $_POST, $_GET,... so use

### DIFF
--- a/PHPYAM/core/Router.php
+++ b/PHPYAM/core/Router.php
@@ -111,7 +111,7 @@ abstract class Router implements IRouter
                     'from' => 'UTF-8',
                     'to' => CLIENT_CHARSET
                 ));
-                $_REQUEST = array_merge($_REQUEST, $GLOBALS['_' . $_SERVER['REQUEST_METHOD']]);
+                $_REQUEST = array_replace($_REQUEST, $GLOBALS['_' . $_SERVER['REQUEST_METHOD']]);
             }
         }
 

--- a/PHPYAM/libs/IntelliForm.php
+++ b/PHPYAM/libs/IntelliForm.php
@@ -158,7 +158,7 @@ class IntelliForm
         } elseif (isset($_SESSION['antz_post'])) {
             $_POST = $_SESSION['antz_post'];
             $_FILES = $_SESSION['antz_files'];
-            $_REQUEST = array_merge($_REQUEST, $_POST);
+            $_REQUEST = array_replace($_REQUEST, $_POST);
             unset($_SESSION['antz_post']);
         }
     }


### PR DESCRIPTION
array_replace() and not array_merge()