### PR TITLE
- add new constant PHPYAM_CATCH_INTERNAL_PHP_ERRORS to let PHPYAM also

### DIFF
--- a/PHPYAM/core/Router.php
+++ b/PHPYAM/core/Router.php
@@ -1,11 +1,10 @@
 <?php
 namespace PHPYAM\core;
 
-use PHPYAM\core\interfaces\IRouter as IRouter;
-use PHPYAM\core\Core as Core;
-use PHPYAM\libs\IntelliForm as IntelliForm;
-use PHPYAM\libs\Assert as Assert;
-use PHPYAM\libs\RouterException as RouterException;
+use PHPYAM\core\interfaces\IRouter;
+use PHPYAM\libs\Assert;
+use PHPYAM\libs\IntelliForm;
+use PHPYAM\libs\RouterException;
 
 /**
  * Class used to translate the URL of a web request into a call to a class and a method
@@ -185,7 +184,10 @@ abstract class Router implements IRouter
             } else {
                 $this->call(ERROR_CONTROLLER, ERROR_ACTION, $msgs);
             }
-        } catch (\Exception $ex) {
+        } catch (\Throwable $ex) {
+            if ($ex instanceof \Error && ! (defined('PHPYAM_CATCH_INTERNAL_PHP_ERRORS') && PHPYAM_CATCH_INTERNAL_PHP_ERRORS)) {
+                throw $ex;
+            }
             // Do not send this exception, simply print it.
             // We're on the error page, there's not much to do when the error
             // page itself contains errors!
@@ -411,7 +413,10 @@ abstract class Router implements IRouter
             $this->endRouterOnError(array(
                 $ex->getMessage()
             ));
-        } catch (\Exception $ex) {
+        } catch (\Throwable $ex) {
+            if ($ex instanceof \Error && ! (defined('PHPYAM_CATCH_INTERNAL_PHP_ERRORS') && PHPYAM_CATCH_INTERNAL_PHP_ERRORS)) {
+                throw $ex;
+            }
             if (constant('USE_LOG4PHP')) {
                 \Logger::getLogger(__CLASS__)->error($ex);
             }

--- a/PHPYAM/libs/Assert.php
+++ b/PHPYAM/libs/Assert.php
@@ -1,8 +1,6 @@
 <?php
 namespace PHPYAM\libs;
 
-use PHPYAM\libs\AssertException as AssertException;
-
 /**
  * Utility classes.
  *

--- a/confs/development.php
+++ b/confs/development.php
@@ -101,7 +101,7 @@ define('URL', getenv('REDIRECT_HTTP_YAM_REWRITEBASE'));
 //define('DROP_ALL_ODBC_CONNECTIONS_ON_FATAL_ERROR', true);
 
 /**
- * Should we unset and destroy current PHP session when an exception occurred while
+ * Should we unset and destroy current PHP session when a "Throwable" occurred while
  * using PHPYAM?
  * Note: current PHP session will never be dropped when a \PHPYAM\core\RouterException was thrown.
  * Such \PHPYAM\core\RouterException should only be thrown by the developer in case of legitimate errors
@@ -115,6 +115,21 @@ define('URL', getenv('REDIRECT_HTTP_YAM_REWRITEBASE'));
  * @see \PHPYAM\core\Router::cleanupOnFatalError()
  */
 //define('DROP_SESSION_ON_FATAL_ERROR', true);
+
+/**
+ * Let PHPYAM try to handle (or not) "internal PHP errors" like it does with any other kind of "throwable fatal error".
+ * When this constant is undefined or set to false, the function defined by \set_exception_handler()
+ * will be used to handle "internal PHP errors", i.e. all errors inheriting from base class \Error.
+ * Note: defining a custom error handler through \set_exception_handler() in addition to PHPYAM's own handler is always
+ * a good idea, to be sure to catch "internal PHP errors" that could have escaped the vigilance of PHPYAM.
+ *
+ * <b>Creating this constant is optional</b>,
+ * not creating it will be the same as defining PHPYAM_CATCH_INTERNAL_PHP_ERRORS to false.
+ *
+ * @var boolean
+ * @see \set_exception_handler()
+ */
+//define('PHPYAM_CATCH_INTERNAL_PHP_ERRORS', false);
 
 /**
  * Name of the class used for user authentication.

--- a/confs/production.php
+++ b/confs/production.php
@@ -101,7 +101,7 @@ define('URL', getenv('REDIRECT_HTTP_YAM_REWRITEBASE'));
 //define('DROP_ALL_ODBC_CONNECTIONS_ON_FATAL_ERROR', true);
 
 /**
- * Should we unset and destroy current PHP session when an exception occurred while
+ * Should we unset and destroy current PHP session when a "Throwable" occurred while
  * using PHPYAM?
  * Note: current PHP session will never be dropped when a \PHPYAM\core\RouterException was thrown.
  * Such \PHPYAM\core\RouterException should only be thrown by the developer in case of legitimate errors
@@ -115,6 +115,21 @@ define('URL', getenv('REDIRECT_HTTP_YAM_REWRITEBASE'));
  * @see \PHPYAM\core\Router::cleanupOnFatalError()
  */
 //define('DROP_SESSION_ON_FATAL_ERROR', true);
+
+/**
+ * Let PHPYAM try to handle (or not) "internal PHP errors" like it does with any other kind of "throwable fatal error".
+ * When this constant is undefined or set to false, the function defined by \set_exception_handler()
+ * will be used to handle "internal PHP errors", i.e. all errors inheriting from base class \Error.
+ * Note: defining a custom error handler through \set_exception_handler() in addition to PHPYAM's own handler is always
+ * a good idea, to be sure to catch "internal PHP errors" that could have escaped the vigilance of PHPYAM.
+ *
+ * <b>Creating this constant is optional</b>,
+ * not creating it will be the same as defining PHPYAM_CATCH_INTERNAL_PHP_ERRORS to false.
+ *
+ * @var boolean
+ * @see \set_exception_handler()
+ */
+//define('PHPYAM_CATCH_INTERNAL_PHP_ERRORS', false);
 
 /**
  * Name of the class used for user authentication.


### PR DESCRIPTION
handle "internal PHP errors", i.e. errors inheriting from base class
\Error
- rework some use statements